### PR TITLE
Add 'type' primitive, similar to groff's

### DIFF
--- a/eqn.c
+++ b/eqn.c
@@ -339,7 +339,7 @@ static struct box *eqn_left(int flg, struct box *pre, int sz0, char *fn0)
 	char fn[FNLEN] = "";
 	int sz = sz0;
 	int subsz;
-	int dx = 0, dy = 0;
+	int type, dx = 0, dy = 0;
 	int style = EQN_TSMASK & flg;
 	if (fn0)
 		strcpy(fn, fn0);
@@ -380,6 +380,13 @@ static struct box *eqn_left(int flg, struct box *pre, int sz0, char *fn0)
 		printf(".ft %s\n", grfont);
 		box_sqrt(box, sqrt);
 		box_free(sqrt);
+	} else if (!tok_jmp("type")) {
+		type = typenum(tok_poptext(1));
+		inner = eqn_left(flg, pre, sz, fn);
+		inner->tbeg = inner->tcur = type;
+		box_merge(box, inner, 1);
+		box_free(inner);
+		box->tcur = type;
 	} else if (!tok_jmp("pile") || !tok_jmp("cpile")) {
 		eqn_pile(box, sz, fn, 'c');
 	} else if (!tok_jmp("lpile")) {

--- a/tok.c
+++ b/tok.c
@@ -12,7 +12,7 @@
 
 static char *kwds[] = {
 	"fwd", "down", "back", "up",
-	"bold", "italic", "roman", "font", "fat", "size",
+	"bold", "italic", "roman", "font", "fat", "size", "type",
 	"bar", "dot", "dotdot", "dyad", "hat", "under", "vec", "tilde",
 	"sub", "sup", "from", "to", "vcenter",
 	"left", "right", "over", "sqrt",


### PR DESCRIPTION
This allows to set a type to a whole expression
rather than to a character. This helps in preventing
code duplication when defining complex characters,
and also helps when the same character is
used in two different ways (\\(mu can be used
as an atom for example, in mathematical formulas
such as: ×: R² -> R).